### PR TITLE
Part 7: Add placeholder and show QRCode block in editor view

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "src/index.js",
   "scripts": {
     "build": "wp-scripts build",
+    "lint:js": "wp-scripts lint-js ./src",
     "start": "wp-scripts start"
   },
   "author": "Marcus Kazmierczak",
   "license": "ISC",
   "devDependencies": {
-    "@wordpress/scripts": "^6.0.0"
+    "@wordpress/scripts": "^6.2.0"
   }
 }

--- a/qrcode-block.php
+++ b/qrcode-block.php
@@ -1,5 +1,5 @@
 <?php
- /**
+/**
  * Plugin Name: QRCode Block
  * Plugin URI:  https://github.com/mkaz/qrcode-block
  * Description: A block to insert a QRCode
@@ -11,7 +11,7 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
- add_action( 'init', function() {
+add_action( 'init', function() {
 
 	$asset_file = include( plugin_dir_path( __FILE__ ) . 'build/index.asset.php' );
 
@@ -21,16 +21,18 @@
 		$asset_file['version']
 	);
 
+	wp_register_script( 'mkaz-qrcode-qrcodejs',
+		plugins_url( 'qrcode.min.js', __FILE__),
+	);
+
 	register_block_type( 'mkaz/qrcode-block', array(
 		'editor_script' => 'mkaz-qrcode-block-script',
 	));
 
- });
+});
 
- add_action( 'wp_enqueue_scripts', function() {
-	wp_enqueue_script( 'mkaz-qrcode-qrcodejs',
-		plugins_url( 'qrcode.min.js', __FILE__ )
-	);
+add_action( 'wp_enqueue_scripts', function() {
+	wp_enqueue_script( 'mkaz-qrcode-qrcodejs' );
 
 	wp_enqueue_script( 'mkaz-qrcode-trigger',
 		plugins_url( 'qr-trigger.js', __FILE__ ),
@@ -38,4 +40,10 @@
 		filemtime( plugin_dir_path( __FILE__ ) . 'qr-trigger.js' ),
 		true // in footer
 	);
- });
+});
+
+// load qrcode on editor screen so we can trigger
+// and show the qrcode within the editor
+add_action( 'admin_enqueue_scripts', function() {
+	wp_enqueue_script( 'mkaz-qrcode-qrcodejs' );
+} );

--- a/src/edit.js
+++ b/src/edit.js
@@ -1,0 +1,18 @@
+import {
+	TextControl,
+} from '@wordpress/components';
+
+
+const edit = ( { attributes, setAttributes } ) => {
+	return (
+		<div>
+			<TextControl
+				label="URL"
+				value={ attributes.url }
+				onChange={ ( val ) => setAttributes( { url: val } ) }
+			/>
+		</div>
+	);
+};
+
+export default edit;

--- a/src/edit.js
+++ b/src/edit.js
@@ -1,16 +1,45 @@
 import {
+	Placeholder,
 	TextControl,
 } from '@wordpress/components';
 
+import { useEffect } from '@wordpress/element';
 
-const edit = ( { attributes, setAttributes } ) => {
+const edit = ( { attributes, isSelected, setAttributes } ) => {
+	useEffect( () => {
+		if ( !isSelected ) {
+			const elem = document.getElementById("qrcode");
+			if ( elem ) {
+				const url = elem.dataset.url; // reads data-url
+				const qrcode = new QRCode(elem, {
+					text: url,
+					width: 256,
+					height: 256,
+					colorDark : "#000000",
+					colorLight : "#ffffff",
+					correctLevel : QRCode.CorrectLevel.H
+				});
+			}
+		}
+	});
+
 	return (
 		<div>
-			<TextControl
-				label="URL"
-				value={ attributes.url }
-				onChange={ ( val ) => setAttributes( { url: val } ) }
-			/>
+			{ attributes.url && ! isSelected
+				? <div
+					id="qrcode"
+					data-url={ attributes.url }
+				></div>
+				: <Placeholder
+					label="QRCode Block"
+					instructions="Add URL for QRCode"
+				>
+					<TextControl
+						value={ attributes.url }
+						onChange={ ( val ) => setAttributes( { url: val } ) }
+					/>
+				</Placeholder>
+			}
 		</div>
 	);
 };

--- a/src/edit.js
+++ b/src/edit.js
@@ -7,30 +7,30 @@ import { useEffect } from '@wordpress/element';
 
 const edit = ( { attributes, isSelected, setAttributes } ) => {
 	useEffect( () => {
-		if ( !isSelected ) {
-			const elem = document.getElementById("qrcode");
+		if ( ! isSelected ) {
+			const elem = document.getElementById( 'qrcode' );
 			if ( elem ) {
-				const url = elem.dataset.url; // reads data-url
-				const qrcode = new QRCode(elem, {
+				const url = elem.dataset.url;
+				new QRCode( elem, {
 					text: url,
 					width: 256,
 					height: 256,
-					colorDark : "#000000",
-					colorLight : "#ffffff",
-					correctLevel : QRCode.CorrectLevel.H
-				});
+					colorDark: '#000000',
+					colorLight: '#ffffff',
+					correctLevel: QRCode.CorrectLevel.H,
+				} );
 			}
 		}
-	});
+	} );
 
 	return (
 		<div>
-			{ attributes.url && ! isSelected
-				? <div
+			{ attributes.url && ! isSelected ?
+				<div
 					id="qrcode"
 					data-url={ attributes.url }
-				></div>
-				: <Placeholder
+				></div> :
+				<Placeholder
 					label="QRCode Block"
 					instructions="Add URL for QRCode"
 				>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
-import { TextControl } from '@wordpress/components';
+
+import edit from './edit';
+import save from './save';
 
 registerBlockType( 'mkaz/qrcode-block', {
 	title: 'QRCode Block',
@@ -13,20 +15,7 @@ registerBlockType( 'mkaz/qrcode-block', {
 			selector: '#qrcode',
 		},
 	},
-	edit: ( { attributes, setAttributes } ) => {
-		return (
-			<div>
-				<TextControl
-					label="URL"
-					value={ attributes.url }
-					onChange={ ( val ) => setAttributes( { url: val } ) }
-				/>
-			</div>
-		);
-	},
-	save: ( { attributes } ) => {
-		return (
-			<div id="qrcode" data-url={ attributes.url }></div>
-		);
-	}
+	edit,
+	save,
+
 });

--- a/src/index.js
+++ b/src/index.js
@@ -18,4 +18,4 @@ registerBlockType( 'mkaz/qrcode-block', {
 	edit,
 	save,
 
-});
+} );

--- a/src/save.js
+++ b/src/save.js
@@ -6,3 +6,4 @@ const save = ( { attributes } ) => {
 };
 
 export default save;
+

--- a/src/save.js
+++ b/src/save.js
@@ -1,0 +1,8 @@
+
+const save = ( { attributes } ) => {
+	return (
+		<div id="qrcode" data-url={ attributes.url }></div>
+	);
+};
+
+export default save;


### PR DESCRIPTION

This set of changes adds the Placeholder component, and shows the QRCode block.
See the blog post for full details.

I also added the lint script from [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) and updated various small lint issues. 